### PR TITLE
ajax2重送信の解消

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -34,14 +34,15 @@ $(function(){
         `</p>` +
       `</div>` +
     `</div>`
-    } ;
+    };
     return html;
   };
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action')
-    $.ajax({
+    var jqxhr;
+    jqxhr = $.ajax({
       url:url,
       type:'POST',
       data:formData,
@@ -50,7 +51,7 @@ $(function(){
       contentType: false
     })
     .done(function(data){
-    
+
       if(Object.keys(data).length == 0){
         alert("メッセージが空です")
         $('.send-btn').prop('disabled', false);

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %meta{content: 'text/html; charset=UTF-8', http:{equiv: 'Content-Type'}}
-    
+
     %title ChatSpace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
@@ -10,7 +10,6 @@
     = stylesheet_link_tag    'application', media: 'all'
     %meta{:content => "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no", :name => "viewport"}/
 
-    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,6 +1,6 @@
 .main-chat
   .main-chat__header
-    
+
     .main-chat__header__right-content
       = link_to 'Edit', edit_group_path(@group)
     .main-chat__header__left-content
@@ -13,21 +13,21 @@
         = @group.name
       .main-chat__header__left-content__user-name
         - @group.users.each do|user|
-          = user.name 
+          = user.name
     .main-chat__header__member
       Member:
   .main-chat__main-content
     .main-chat__main-content__message-space
       = render @messages
-      
-    
+
+
   .main-chat__footer
     .main-chat__footer__a
       .main-chat__footer__a__form
         = form_for [@group, @message] do |f|
           = f.text_area :content, class: 'form__message', placeholder: 'type a message'
           -# .main-chat__footer__a__form__icon
-          -#   =f.label :image, class:'form__icon__form-image'do  
+          -#   =f.label :image, class:'form__icon__form-image'do
           -#     = icon('fas', 'image', class: 'icon')
           -#     = f.file_field :image, class: 'hidden'
           .main-chat__footer__a__form__send-btn

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@ default: &default
   encoding: utf8
   pool: 5
   username: root
-  password: 
+  password:
   socket: /tmp/mysql.sock
 
 development:


### PR DESCRIPTION
ajaxの2重送信を解消いたしました。
原因は views/layouts/application.html.haml のheadタグにJavaScriptを読み込む記述が2個あったためでした。